### PR TITLE
Fix/omniauth user edit info

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,10 +2,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
   def update_resource(resource, params)
-    if resource.provider == "google_oauth2"
+    if resource.provider == "google_oauth2" && resource.info_changed == false
       params.delete("current_password")
       resource.password = params['password']
-      
+      resource.info_changed = true
       resource.update_without_password(params)
     else
       resource.update_with_password(params)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,7 @@ class User < ApplicationRecord
     user.access_token = auth.credentials.token
     user.expires_at = auth.credentials.expires_at
     user.refresh_token = auth.credentials.refresh_token
+    user.info_changed = false
     user.save
     
     user

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,8 +38,16 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%= f.label :password %> 
+    <% if current_user.info_changed? %>
+      <i>(leave blank if you don't want to change it)</i>
+    <%end%>
+    <br />
+    <% if current_user.info_changed? %>
+      <%= f.password_field :password, autocomplete: "new-password" %>
+    <%else%>
+      <%= f.password_field :password, autocomplete: "new-password", required: true %>
+    <%end%>
     <% if @minimum_password_length %>
       <br />
       <em><%= @minimum_password_length %> characters minimum</em>
@@ -48,19 +56,21 @@
 
   <div class="field">
     <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <% if current_user.info_changed? %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%else%>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true %>
+    <%end%>
   </div>
 
-  <div class="field">
-    <%= f.label :current_password %> 
-    <i>(we need your current password to confirm your changes)</i> 
-    <% if current_user.provider != nil %>
+  <% unless current_user.info_changed == false %>
+    <div class="field">
+      <%= f.label :current_password %> 
+      <i>(we need your current password to confirm your changes)</i> 
       <br>
-      <i>(if this is your first time setting up your account, you can just type here your password from above.)</i> 
-    <%end%>
-    <br>
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
+      <%= f.password_field :current_password, autocomplete: "current-password" %>
+    </div>
+  <%end%>
 
   <div class="actions">
     <%= f.submit "Update" %>

--- a/db/migrate/20220805020117_add_info_changed_to_users.rb
+++ b/db/migrate/20220805020117_add_info_changed_to_users.rb
@@ -1,0 +1,5 @@
+class AddInfoChangedToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :info_changed, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_04_083903) do
+ActiveRecord::Schema.define(version: 2022_08_05_020117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2022_08_04_083903) do
     t.string "access_token"
     t.string "refresh_token"
     t.integer "expires_at"
+    t.boolean "info_changed", default: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
When applied, the changes will modify the logic for handling user info edit for omniauth users and manual login users.

After pulling, make sure to run

`rails db:migrate`

to apply the migration changes.

if there are errors, run

`rails db:drop db:create db:migrate db:seed`

to completely refresh the tables and schema.