### PR TITLE
modify paymongo redirect for production

### DIFF
--- a/app/api/paymongo/v1/gcash_gateway.rb
+++ b/app/api/paymongo/v1/gcash_gateway.rb
@@ -4,8 +4,8 @@ module Paymongo
       include ApiErrors
       PUBLIC_KEY = ENV["PAYMONGO_PUBLIC_TEST"]
       SECRET_KEY = ENV["PAYMONGO_SECRET_TEST"]
-      PAYMENT_SUCCESS_REDIRECT = "http://localhost:3000/payments/gcash-payment/success"
-      PAYMENT_FAILED_REDIRECT = "http://localhost:3000/payments/gcash-payment/failed"
+      PAYMENT_SUCCESS_REDIRECT = "https://private-dermatology.herokuapp.com/payments/gcash-payment/success"
+      PAYMENT_FAILED_REDIRECT = "https://private-dermatology.herokuapp.com/payments/gcash-payment/failed"
       COMPANY_NAME = "Private Dermatology"
 
       def _http(url)


### PR DESCRIPTION
this will fix paymongo redirect for production. however, to make the redirect work for development, change the redirect to the previous values.